### PR TITLE
Mpfd parser update

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Libnavajo makes it easy to run an HTTP server into your own application, impleme
 
     git clone https://github.com/titi38/libnavajo.git
 
-    cmake .
+    mkdir build
+
+    cd build
+
+    cmake ..
 
     make
 

--- a/examples/1_basic/Makefile
+++ b/examples/1_basic/Makefile
@@ -5,7 +5,7 @@
 ##############################
 
 OUTPUTFILENAME = PrecompiledRepository.cc
-NAVAJO_PRECOMPILER_EXEC = ../../bin/navajoPrecompiler
+NAVAJO_PRECOMPILER_EXEC = ../../build/bin/navajoPrecompiler
 
 UNAME := $(shell uname)
 LBITS := $(shell getconf LONG_BIT)
@@ -55,7 +55,7 @@ EXAMPLE_OBJS = \
 
 %.o: %.cc
 	$(CXX) -c $< -o $@ $(CXXFLAGS) $(CPPFLAGS) $(DEFS) 
-	
+
 all: $(EXAMPLE_NAME)
 
 PrecompiledRepository.o:
@@ -64,7 +64,7 @@ PrecompiledRepository.o:
 	@find . \( -name "*~" -o -name "*.old" -o -name "*.bak" \) -exec rm -f '{}' \;
 	$(NAVAJO_PRECOMPILER_EXEC) exampleRepository >> $(OUTPUTFILENAME) ; cd ..
 	$(CXX) -c PrecompiledRepository.cc -o $@ $(CXXFLAGS) $(CPPFLAGS) $(DEFS)
-	
+
 $(EXAMPLE_NAME): $(EXAMPLE_OBJS) $(LIB_STATIC_NAME)
 	rm -f $@
 	$(LD) $(LDFLAGS) -o $@ $(EXAMPLE_OBJS) $(LIB_STATIC_NAME) $(LIBS) 

--- a/examples/1_basic/example.cc
+++ b/examples/1_basic/example.cc
@@ -45,8 +45,8 @@ class MyDynamicPage: public DynamicPage
     *cptExample=*cptExample+1;    
     //
 
-    string content="<HTML><BODY>";
-    string param;
+    std::string content="<HTML><BODY>";
+    std::string param;
     if (request->getParameter("param1", param))
     {
       //int pint=getValue<int>(param);
@@ -55,7 +55,7 @@ class MyDynamicPage: public DynamicPage
     else
       content+="param1 hasn't been set";
 
-    stringstream myAttributess; myAttributess << *cptExample;
+    std::stringstream myAttributess; myAttributess << *cptExample;
     content+="<BR/>my session attribute myAttribute contains "+myAttributess.str();
 
     content+="</BODY></HTML>";
@@ -85,7 +85,7 @@ int main()
   //webServer->setAuthPeerSSL(true, "cachain.pem");
   //webServer->addAuthPeerDN("/C=FR/O=CNRS/OU=UMR5821/CN=Thierry Descombes/emailAddress=thierry.descombes@lpsc.in2p3.fr");
 
-  //webServer->addHostsAllowed(IpNetwork(string("134.158.40.0/21")));
+  //webServer->addHostsAllowed(IpNetwork(std::string("134.158.40.0/21")));
 
   //uncomment to active login/passwd auth
   //webServer->addLoginPass("login","password");

--- a/examples/2_gauge/Makefile
+++ b/examples/2_gauge/Makefile
@@ -5,7 +5,7 @@
 ##############################
 
 OUTPUTFILENAME = PrecompiledRepository.cc
-NAVAJO_PRECOMPILER_EXEC = ../bin/navajoPrecompiler
+NAVAJO_PRECOMPILER_EXEC = ../../build/bin/navajoPrecompiler
 
 UNAME := $(shell uname)
 LBITS := $(shell getconf LONG_BIT)
@@ -57,9 +57,9 @@ EXAMPLE_OBJS = \
 
 %.o: %.cc
 	$(CXX) -c $< -o $@ $(CXXFLAGS) $(CPPFLAGS) $(DEFS) 
-	
+
 all: $(EXAMPLE_NAME)
-	
+
 $(EXAMPLE_NAME): $(EXAMPLE_OBJS) $(LIB_STATIC_NAME)
 	rm -f $@
 	$(LD) $(LDFLAGS) -o $@ $(EXAMPLE_OBJS) $(LIB_STATIC_NAME) $(LIBS) 

--- a/examples/2_gauge/example.cc
+++ b/examples/2_gauge/example.cc
@@ -83,7 +83,7 @@ class MyDynamicRepository : public DynamicRepository
     {
       bool getPage(HttpRequest* request, HttpResponse *response)
       {
-        string login, password;
+	std::string login, password;
         // User libnavajo/libnavajo is allowed
         if (request->getParameter("login", login) && request->getParameter("pass", password)
             && (login == "libnavajo" && password == "libnavajo"))
@@ -103,7 +103,7 @@ class MyDynamicRepository : public DynamicRepository
       {
         if (!isValidSession(request))
           return fromString("ERR", response);;
-        ostringstream ss;
+	std::ostringstream ss;
         ss << getCpuLoad();
         return fromString(ss.str(), response);
       }
@@ -113,7 +113,7 @@ class MyDynamicRepository : public DynamicRepository
     {
       bool getPage(HttpRequest* request, HttpResponse *response)
       {
-        string param;
+	std::string param;
 
         if (request->getParameter("pageId", param) && param == "LOGIN" && isValidSession(request))
         {

--- a/examples/3_websocket/Makefile
+++ b/examples/3_websocket/Makefile
@@ -5,7 +5,7 @@
 ##############################
 
 OUTPUTFILENAME = PrecompiledRepository.cc
-NAVAJO_PRECOMPILER_EXEC = ../../bin/navajoPrecompiler
+NAVAJO_PRECOMPILER_EXEC = ../../build/bin/navajoPrecompiler
 
 UNAME := $(shell uname)
 LBITS := $(shell getconf LONG_BIT)
@@ -38,7 +38,7 @@ endif
 
 CPPFLAGS	= -I. \
                   -I../../include         \
-       		  -I$(LIBSSL_DIR)/include
+		  -I$(LIBSSL_DIR)/include
 
 LD		=  g++
 
@@ -57,7 +57,7 @@ EXAMPLE_OBJS = \
 
 %.o: %.cc
 	$(CXX) -c $< -o $@ $(CXXFLAGS) $(CPPFLAGS) $(DEFS) 
-	
+
 all: $(EXAMPLE_NAME)
 
 PrecompiledRepository.o:
@@ -66,7 +66,7 @@ PrecompiledRepository.o:
 	@find . \( -name "*~" -o -name "*.old" -o -name "*.bak" \) -exec rm -f '{}' \;
 	@$(NAVAJO_PRECOMPILER_EXEC) exampleRepository >> $(OUTPUTFILENAME) ; cd ..
 	$(CXX) -c PrecompiledRepository.cc -o $@ $(CXXFLAGS) $(CPPFLAGS) $(DEFS)
-	
+
 $(EXAMPLE_NAME): $(EXAMPLE_OBJS) $(LIB_STATIC_NAME)
 	rm -f $@
 	$(LD) $(LDFLAGS) -o $@ $(EXAMPLE_OBJS) $(LIB_STATIC_NAME) $(LIBS) 

--- a/examples/3_websocket/example.cc
+++ b/examples/3_websocket/example.cc
@@ -33,7 +33,7 @@ class MyWebSocket : public WebSocket
     return true;
   }
 
-  void onTextMessage(WebSocketClient* client, const string &message, const bool fin)
+  void onTextMessage(WebSocketClient* client, const std::string &message, const bool fin)
   {
     printf ("Message: '%s' received from host '%s'\n", message.c_str(), client->getHttpRequest()->getPeerIpAddress().str().c_str());
     client->sendTextMessage("The message has been received!");
@@ -63,7 +63,7 @@ int main()
   //webServer->setAuthPeerSSL(true, "cachain.pem");
   //webServer->addAuthPeerDN("/C=FR/O=CNRS/OU=UMR5821/CN=Thierry Descombes/emailAddress=thierry.descombes@lpsc.in2p3.fr");
 
-  //webServer->addHostsAllowed(IpNetwork(string("134.158.40.0/21")));
+  //webServer->addHostsAllowed(IpNetwork(std::string("134.158.40.0/21")));
 
   //uncomment to active login/passwd auth
   //webServer->addLoginPass("login","password");

--- a/examples/4_wsChat/Makefile
+++ b/examples/4_wsChat/Makefile
@@ -5,7 +5,7 @@
 ##############################
 
 OUTPUTFILENAME = PrecompiledRepository.cc
-NAVAJO_PRECOMPILER_EXEC = ../../bin/navajoPrecompiler
+NAVAJO_PRECOMPILER_EXEC = ../../build/bin/navajoPrecompiler
 
 UNAME := $(shell uname)
 LBITS := $(shell getconf LONG_BIT)
@@ -37,7 +37,7 @@ endif
 
 
 CPPFLAGS	= -I. \
-       		  -I$(LIBSSL_DIR)/include \
+		  -I$(LIBSSL_DIR)/include \
 		  -I../../include         \
                   -I../../MPFDParser-1.1.1
 
@@ -58,7 +58,7 @@ EXAMPLE_OBJS = \
 
 %.o: %.cc
 	$(CXX) -c $< -o $@ $(CXXFLAGS) $(CPPFLAGS) $(DEFS) 
-	
+
 all: $(EXAMPLE_NAME)
 
 PrecompiledRepository.o:
@@ -67,7 +67,7 @@ PrecompiledRepository.o:
 	@find . \( -name "*~" -o -name "*.old" -o -name "*.bak" \) -exec rm -f '{}' \;
 	@$(NAVAJO_PRECOMPILER_EXEC) exampleRepository >> $(OUTPUTFILENAME) ; cd ..
 	$(CXX) -c PrecompiledRepository.cc -o $@ $(CXXFLAGS) $(CPPFLAGS) $(DEFS)
-	
+
 $(EXAMPLE_NAME): $(EXAMPLE_OBJS) $(LIB_STATIC_NAME)
 	rm -f $@
 	$(LD) $(LDFLAGS) -o $@ $(EXAMPLE_OBJS) $(LIB_STATIC_NAME) $(LIBS) 

--- a/examples/4_wsChat/example.cc
+++ b/examples/4_wsChat/example.cc
@@ -45,7 +45,7 @@ void setSessionIsConnected(HttpRequest* request, const bool b)
 
 /***********************************************************************/
 
-bool checkMessage(HttpRequest* request, const string msg)
+bool checkMessage(HttpRequest* request, const std::string msg)
 {
   char *username = (char *)request->getSessionAttribute("username");
   return msg.length() > strlen(username)
@@ -63,7 +63,7 @@ class MyDynamicRepository : public DynamicRepository
         #ifdef DEBUG_TRACES
         NVJ_LOG->append(NVJ_DEBUG, "Connect");
         #endif
-        string login, password;
+	std::string login, password;
         // User libnavajo/libnavajo is allowed !
         if (request->getParameter("login", login) && request->getParameter("pass", password)
             && (login == "libnavajo" && password == "libnavajo"))
@@ -122,7 +122,7 @@ class MyWebSocket : public WebSocket
     setSessionIsConnected(request, false);
   }
 
-  void onTextMessage(WebSocketClient* client, const string &message, const bool fin)
+  void onTextMessage(WebSocketClient* client, const std::string &message, const bool fin)
   {
     HttpRequest* request=client->getHttpRequest();
     printf ("Message: '%s' received from host '%s'\n", message.c_str(), request->getPeerIpAddress().str().c_str());
@@ -161,7 +161,7 @@ int main()
   //webServer->setAuthPeerSSL(true, "cachain.pem");
   //webServer->addAuthPeerDN("/C=FR/O=CNRS/OU=UMR5821/CN=Thierry Descombes/emailAddress=thierry.descombes@lpsc.in2p3.fr");
 
-  //webServer->addHostsAllowed(IpNetwork(string("134.158.40.0/21")));
+  //webServer->addHostsAllowed(IpNetwork(std::string("134.158.40.0/21")));
 
   //uncomment to active login/passwd auth
   //webServer->addLoginPass("login","password");

--- a/examples/5_multipart/Makefile
+++ b/examples/5_multipart/Makefile
@@ -4,7 +4,7 @@
 #                    2016    #
 ##############################
 
-NAVAJO_PRECOMPILER_EXEC = ../bin/navajoPrecompiler
+NAVAJO_PRECOMPILER_EXEC = ../../build/bin/navajoPrecompiler
 
 UNAME := $(shell uname)
 LBITS := $(shell getconf LONG_BIT)
@@ -56,9 +56,9 @@ EXAMPLE_OBJS = \
 
 %.o: %.cc
 	$(CXX) -c $< -o $@ $(CXXFLAGS) $(CPPFLAGS) $(DEFS) 
-	
+
 all: $(EXAMPLE_NAME)
-	
+
 $(EXAMPLE_NAME): $(EXAMPLE_OBJS) $(LIB_STATIC_NAME)
 	rm -f $@
 	mkdir -p upload

--- a/examples/5_multipart/example.cc
+++ b/examples/5_multipart/example.cc
@@ -53,7 +53,7 @@ class MyDynamicRepository : public DynamicRepository
 
             // Copy files to upload directory
             std::ifstream  src( fields[it->first]->GetTempFileName().c_str(), std::ios::binary);
-            string dstFilename= string(UPLOAD_DIR)+'/'+fields[it->first]->GetFileName();
+	    std::string dstFilename= std::string(UPLOAD_DIR)+'/'+fields[it->first]->GetFileName();
             std::ofstream  dst( dstFilename.c_str(), std::ios::binary);
             if (!src || !dst)
               NVJ_LOG->append(NVJ_ERROR, "Copy error: check read/write permissions");
@@ -74,12 +74,12 @@ class MyDynamicRepository : public DynamicRepository
     {
       bool getPage(HttpRequest* request, HttpResponse *response)
       {
-        string json = "{ \"data\" : [";
-        set< string >* filenames = myUploadRepo->getFilenames();
+	std::string json = "{ \"data\" : [";
+	std::set< std::string >* filenames = myUploadRepo->getFilenames();
         std::set<std::string>::iterator it = filenames->begin(); 
         while (it != filenames->end())
         {
-          json += string("\"") + it->c_str() + '\"';
+          json += std::string("\"") + it->c_str() + '\"';
           if (++it != filenames->end()) 
             json += ", ";
         }

--- a/include/MPFDParser/Field.h
+++ b/include/MPFDParser/Field.h
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sstream>
+#include <vector>
 
 namespace MPFD {
 
@@ -51,7 +52,6 @@ namespace MPFD {
 
 
     private:
-        unsigned long FieldContentLength;
 
         int WhereToStoreUploadedFiles;
 
@@ -59,7 +59,7 @@ namespace MPFD {
         std::string FileContentType, FileName;
 
         int type;
-        char * FieldContent;
+	std::vector<char> FieldContent;
         std::ofstream file;
 
     };

--- a/include/MPFDParser/Parser.h
+++ b/include/MPFDParser/Parser.h
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <string>
 #include <map>
+#include <vector>
 #include "Exception.h"
 #include "Field.h"
 #include <string.h>
@@ -34,7 +35,7 @@ namespace MPFD {
 
         void SetMaxCollectedDataLength(long max);
         void SetTempDirForFileUpload(std::string dir);
-        inline std::string GetTempDirForFileUpload() { return TempDirForFileUpload; };
+	inline std::string GetTempDirForFileUpload() { return TempDirForFileUpload; };
         void SetUploadedFilesStorage(int where);
 
         std::map<std::string, Field *> GetFieldsMap();
@@ -56,9 +57,8 @@ namespace MPFD {
         std::string Boundary;
         std::string ProcessingFieldName;
         bool _HeadersOfTheFieldAreProcessed;
- //       long ContentLength;
-        char *DataCollector;
-        long DataCollectorLength, MaxDataCollectorLength;
+	std::vector<char> DataCollector;
+        long MaxDataCollectorLength;
         bool FindStartingBoundaryAndTruncData();
         void _ProcessData();
         void _ParseHeaders(std::string headers);

--- a/include/libnavajo/DynamicPage.hh
+++ b/include/libnavajo/DynamicPage.hh
@@ -27,7 +27,7 @@ class DynamicPage
 
     /**********************************************************************/
      
-    template<class T> static inline T getValue (string s)
+    template<class T> static inline T getValue (std::string s)
     { 
       if (!s.length())
        throw std::bad_cast();
@@ -52,7 +52,7 @@ class DynamicPage
 
     /**********************************************************************/
     
-    inline bool fromString( const string& resultat, HttpResponse *response )
+    inline bool fromString( const std::string& resultat, HttpResponse *response )
     {
       size_t webpageLen;
       unsigned char *webpage;

--- a/include/libnavajo/DynamicRepository.hh
+++ b/include/libnavajo/DynamicRepository.hh
@@ -37,11 +37,11 @@ class DynamicRepository : public WebRepository
     { 
       size_t i=0; 
       while (url.size() && url[i]=='/') i++;
-      indexMap.insert(pair<string, DynamicPage *>(url.substr(i, url.size()-i), page)); };
+      indexMap.insert(std::pair<std::string, DynamicPage *>(url.substr(i, url.size()-i), page)); };
 
     inline virtual bool getFile(HttpRequest* request, HttpResponse *response)
     {
-      string url = request->getUrl();
+      std::string url = request->getUrl();
       while (url.size() && url[0]=='/') url.erase(0, 1);
       pthread_mutex_lock( &_mutex );
       IndexMap::const_iterator i = indexMap.find (url);

--- a/include/libnavajo/HttpRequest.hh
+++ b/include/libnavajo/HttpRequest.hh
@@ -36,7 +36,7 @@ typedef struct
   CompressionMode compression;
   SSL *ssl;
   BIO *bio;
-  string *peerDN;
+  std::string *peerDN;
 } ClientSockData;
 
 class HttpRequest
@@ -355,7 +355,7 @@ class HttpRequest
     * @param params:  raw http parameters string
     * @cookies params: raw http cookies string
     */         
-    HttpRequest(const HttpRequestMethod type, const char *url, const char *params, const char *cookies, const char *origin, const string &username, ClientSockData *client, MPFD::Parser *parser=NULL) 
+    HttpRequest(const HttpRequestMethod type, const char *url, const char *params, const char *cookies, const char *origin, const std::string &username, ClientSockData *client, MPFD::Parser *parser=NULL)
     { 
       this->httpMethod = type;
       this->url = url;
@@ -422,7 +422,7 @@ class HttpRequest
     * get http authentification username
     * @return the login
     */    
-    inline string& getHttpAuthUsername()
+    inline std::string& getHttpAuthUsername()
     {
       return httpAuthUsername;
     };
@@ -432,7 +432,7 @@ class HttpRequest
     * get peer x509 dn 
     * @return the DN of the peer certificate
     */   
-    inline string& getX509PeerDN()
+    inline std::string& getX509PeerDN()
     {
       return *(clientSockData->peerDN);
     };

--- a/include/libnavajo/HttpResponse.hh
+++ b/include/libnavajo/HttpResponse.hh
@@ -24,7 +24,7 @@ class HttpResponse
   std::string mimeType;
   std::string forwardToUrl;
   bool cors, corsCred;
-  string corsDomain;
+  std::string corsDomain;
   
   public:
     HttpResponse(std::string mime="") : responseContent (NULL), responseContentLength (0), zippedFile (false), mimeType(mime), forwardToUrl(""), cors(false), corsCred(false), corsDomain("")
@@ -182,7 +182,7 @@ class HttpResponse
     * @param cors: enabled or not
     * @param cred: enabled credentials or not
     */    
-    void setCORS(bool cors=true, bool cred=false, string domain="*")
+    void setCORS(bool cors=true, bool cred=false, std::string domain="*")
     {
       this->cors=cors;
       corsCred=cred;
@@ -203,7 +203,7 @@ class HttpResponse
       return corsCred;
     }
     
-    string& getCORSdomain()
+    std::string& getCORSdomain()
     {
       return corsDomain;
     };

--- a/include/libnavajo/IpAddress.hh
+++ b/include/libnavajo/IpAddress.hh
@@ -138,9 +138,9 @@ class IpAddress
 	  return res;
   };
 
-  inline const bool isUndef() const { return ipversion == 0; };
+  inline bool isUndef() const { return ipversion == 0; };
 
-  inline const std::string str() const
+  inline std::string str() const
   {
     std::string res="";
     if (ipversion == 4)

--- a/include/libnavajo/IpAddress.hh
+++ b/include/libnavajo/IpAddress.hh
@@ -51,7 +51,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-using namespace std;
 
 #define INET6_ADDRLEN 	16
 
@@ -85,7 +84,7 @@ class IpAddress
   IpAddress(const in6_addr &addrIPv6) :
 	  ipversion(6) { memcpy ((void*)&(ip.v6), (void*)(&addrIPv6), INET6_ADDRLEN); };
 
-  IpAddress(const string& value)
+  IpAddress(const std::string& value)
   {
     init();
     if ( index(value.c_str(), ':') != NULL ) // IPv6
@@ -141,9 +140,9 @@ class IpAddress
 
   inline const bool isUndef() const { return ipversion == 0; };
 
-  inline const string str() const
+  inline const std::string str() const
   {
-    string res="";
+    std::string res="";
     if (ipversion == 4)
     {
       struct in_addr iplocal;
@@ -191,7 +190,7 @@ class IpAddress
     return (!error);
   };
 
-  inline static IpAddress* fromString(const string& value)
+  inline static IpAddress* fromString(const std::string& value)
   {
     IpAddress* newIp =  new IpAddress(value);
 
@@ -223,7 +222,7 @@ class IpNetwork
       { addr = a; mask=m;  };
 
 
-  // TODO: IpNetwork(const string& value)
+  // TODO: IpNetwork(const std::string& value)
   
 
     inline bool operator<(const IpNetwork& A) const
@@ -269,9 +268,9 @@ class IpNetwork
       return false;
     };
 
-    inline string strCIDR() const
+    inline std::string strCIDR() const
     {
-      string netCIDR=addr.str()+"/";
+      std::string netCIDR=addr.str()+"/";
       std::stringstream masklengthSs; masklengthSs << (int)mask;
       netCIDR+=masklengthSs.str();
       return netCIDR;
@@ -321,12 +320,12 @@ class IpNetwork
       return res;
     };
 
-    inline static IpNetwork* fromString(const string& value)
+    inline static IpNetwork* fromString(const std::string& value)
     {
       IpNetwork *ipNet=NULL;
-      string ipstr;
+      std::string ipstr;
       size_t found=value.find_first_of('/');
-      if (found == string::npos)
+      if (found == std::string::npos)
       {
         IpAddress *addr=IpAddress::fromString(value);
         if (addr==NULL) return NULL;
@@ -342,10 +341,10 @@ class IpNetwork
         if (addr==NULL) return NULL;
 
         u_int8_t maskDec=0;
-        string maskStr=value.substr(found+1);
+        std::string maskStr=value.substr(found+1);
 
         // Mask
-        if ( maskStr.find_first_of('.') != string::npos ) // mask is formating like "w.x.y.z"
+        if ( maskStr.find_first_of('.') != std::string::npos ) // mask is formating like "w.x.y.z"
         {
 	        if (addr->ipversion == 6)
 	        {

--- a/include/libnavajo/LocalRepository.hh
+++ b/include/libnavajo/LocalRepository.hh
@@ -20,31 +20,30 @@
 #include <string>
 #include "libnavajo/nvjThread.h"
 
-using namespace std;
 
 class LocalRepository : public WebRepository
 {
     pthread_mutex_t _mutex;
 
-    set< string > filenamesSet; // list of available files
-    //pair<string,string> aliasesSet; // alias name | Path to local directory
-    string aliasName;
-    string fullPathToLocalDir;
+    std::set< std::string > filenamesSet; // list of available files
+    //pair<std::string,std::string> aliasesSet; // alias name | Path to local directory
+    std::string aliasName;
+    std::string fullPathToLocalDir;
 
-    bool loadFilename_dir(const string& alias, const string& path, const string& subpath="");
-    bool fileExist(const string& url);
+    bool loadFilename_dir(const std::string& alias, const std::string& path, const std::string& subpath="");
+    bool fileExist(const std::string& url);
 
     
   public:
-    LocalRepository (const string& alias, const string& dirPath);
+    LocalRepository (const std::string& alias, const std::string& dirPath);
     virtual ~LocalRepository () { };
 
     virtual bool getFile(HttpRequest* request, HttpResponse *response);
     virtual void freeFile(unsigned char *webpage) { ::free(webpage); };
-    //void addDirectory(const string& alias, const string& dirPath);    
+    //void addDirectory(const std::string& alias, const std::string& dirPath);
     //void clearAliases();
     void reload();
-    inline set< string >* getFilenames() { return &filenamesSet; }
+    inline std::set< std::string >* getFilenames() { return &filenamesSet; }
     void printFilenames();
 };
 

--- a/include/libnavajo/LogFile.hh
+++ b/include/libnavajo/LogFile.hh
@@ -21,7 +21,6 @@
 
 #include "libnavajo/LogOutput.hh"
 
-using namespace std;
 
   /**
   * LogFile - LogOutput 
@@ -37,7 +36,7 @@ using namespace std;
   
     private:
       char filename[30];
-      ofstream *file;
+      std::ofstream *file;
   
   };
   

--- a/include/libnavajo/LogRecorder.hh
+++ b/include/libnavajo/LogRecorder.hh
@@ -24,7 +24,6 @@
 
 #define NVJ_LOG LogRecorder::getInstance()
 
-using namespace std;
 
 
   /**
@@ -35,7 +34,7 @@ using namespace std;
 
      pthread_mutex_t log_mutex;
      bool debugMode;
-     std::set<string> uniqLog; // Only one entry !
+     std::set<std::string> uniqLog; // Only one entry !
      
     public:
 
@@ -67,7 +66,7 @@ using namespace std;
       void append(const NvjLogSeverity& l, const std::string& msg, const std::string& details="");
       inline void appendUniq(const NvjLogSeverity& l, const std::string& msg, const std::string& details="")
       { 
-	      set<string>::iterator it;
+	      std::set<std::string>::iterator it;
 	      it=uniqLog.find(msg+details);
 	      if (it==uniqLog.end())
 	      {

--- a/include/libnavajo/LogSyslog.hh
+++ b/include/libnavajo/LogSyslog.hh
@@ -21,7 +21,6 @@
 
 #include "libnavajo/LogOutput.hh"
 
-using namespace std;
 
   /**
   * LogSyslog - LogOutput 

--- a/include/libnavajo/WebServer.hh
+++ b/include/libnavajo/WebServer.hh
@@ -49,7 +49,7 @@ class WebServer
     void initialize_ctx(const char *certfile, const char *cafile, const char *password);
     static int password_cb(char *buf, int num, int rwflag, void *userdata);
 
-    bool isUserAllowed(const string &logpassb64, string &username);
+    bool isUserAllowed(const std::string &logpassb64, std::string &username);
     bool isAuthorizedDN(const std::string str);
 
     size_t recvLine(int client, char *bufLine, size_t);
@@ -101,9 +101,9 @@ class WebServer
     bool disableIpV4, disableIpV6;
     ushort tcpPort;
     size_t threadsPoolSize;
-    string device;
+    std::string device;
     
-    string mutipartTempDirForFileUpload;
+    std::string mutipartTempDirForFileUpload;
     long mutipartMaxCollectedDataLength;
     
     bool sslEnabled;
@@ -115,15 +115,15 @@ class WebServer
     std::vector<WebRepository *> webRepositories;
     static inline bool is_base64(unsigned char c)
       { return (isalnum(c) || (c == '+') || (c == '/')); };
-    static const string base64_chars;
+    static const std::string base64_chars;
     static std::string base64_decode(const std::string& encoded_string);
     static std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len);
     static void closeSocket(ClientSockData* client);
     std::map<std::string, WebSocket *> webSocketEndPoints;
-    static std::string SHA1_encode(const string& input);
-    static const string webSocketMagicString;
-    static string generateWebSocketServerKey(string webSocketKey);
-    static string getHttpWebSocketHeader(const char *messageType, const char* webSocketClientKey, const bool webSocketDeflate);
+    static std::string SHA1_encode(const std::string& input);
+    static const std::string webSocketMagicString;
+    static std::string generateWebSocketServerKey(std::string webSocketKey);
+    static std::string getHttpWebSocketHeader(const char *messageType, const char* webSocketClientKey, const bool webSocketDeflate);
 
   public:
     WebServer();
@@ -172,20 +172,20 @@ class WebServer
     * Restricted X509 authentification to a DN user list. Add this given DN.
     * @param dn: user certificate DN
     */ 
-    inline void addAuthPeerDN(const char* dn) { authDnList.push_back(string(dn)); };
+    inline void addAuthPeerDN(const char* dn) { authDnList.push_back(std::string(dn)); };
 
     /**
     * Enabled http authentification for a given login/password list
     * @param login: user login
     * @param pass : user password
     */ 
-    inline void addLoginPass(const char* login, const char* pass) { authLoginPwdList.push_back(string(login)+':'+string(pass)); };
+    inline void addLoginPass(const char* login, const char* pass) { authLoginPwdList.push_back(std::string(login)+':'+std::string(pass)); };
 
     /**
     * Set the path to store uploaded files on disk. Used to set the MPFD function.
     * @param pathdir: path to a writtable directory
     */   
-    inline void setMutipartTempDirForFileUpload(const string& pathdir) { mutipartTempDirForFileUpload = pathdir; };
+    inline void setMutipartTempDirForFileUpload(const std::string& pathdir) { mutipartTempDirForFileUpload = pathdir; };
 
     /**
     * Set the size of internal MPFD buffer.
@@ -210,7 +210,7 @@ class WebServer
     * @param endpoint : websocket endpoint
     * @param websocket : WebSocket instance
     */  
-    void addWebSocket(const string endPoint, WebSocket* websocket) { webSocketEndPoints[endPoint]=websocket; };
+    void addWebSocket(const std::string endPoint, WebSocket* websocket) { webSocketEndPoints[endPoint]=websocket; };
     
     /**
     * IpV4 hosts only

--- a/include/libnavajo/WebSocket.hh
+++ b/include/libnavajo/WebSocket.hh
@@ -23,7 +23,7 @@
 
 class WebSocket
 {
-    list<WebSocketClient*> webSocketClientList;
+    std::list<WebSocketClient*> webSocketClientList;
     pthread_mutex_t webSocketClientList_mutex;
     bool compression;
 
@@ -143,7 +143,7 @@ class WebSocket
     * Send Close Message Notification to all connected clients
     * @param reasonMsg: the message content
     */
-    inline void sendBroadcastCloseCtrlFrame(const string &reasonMsg = "")
+    inline void sendBroadcastCloseCtrlFrame(const std::string &reasonMsg = "")
     {
       sendBroadcastCloseCtrlFrame((const unsigned char*)reasonMsg.c_str(), reasonMsg.length());
     }
@@ -165,7 +165,7 @@ class WebSocket
     * Send Ping Message Notification to all connected clients
     * @param message: the message content
     */
-    inline void sendBroadcastPingCtrlFrame(const string &message)
+    inline void sendBroadcastPingCtrlFrame(const std::string &message)
     {
       sendBroadcastPingCtrlFrame((const unsigned char*)message.c_str(), message.length());
     }
@@ -187,7 +187,7 @@ class WebSocket
     * Send Pong Message Notification to all connected clients
     * @param message: the message content
     */
-    inline void sendBroadcastPongCtrlFrame(const string &message)
+    inline void sendBroadcastPongCtrlFrame(const std::string &message)
     {
       sendBroadcastPongCtrlFrame((const unsigned char*)message.c_str(), message.length());
     }

--- a/include/libnavajo/WebSocketClient.hh
+++ b/include/libnavajo/WebSocketClient.hh
@@ -105,7 +105,7 @@ class WebSocketClient
     * @param message: the text message
     * @param fin: is-it the final fragment of the message ?
     */
-    void sendTextMessage(const string &message, bool fin = true);
+    void sendTextMessage(const std::string &message, bool fin = true);
 
     /**
     * Send Binary Message on the websocket
@@ -129,7 +129,7 @@ class WebSocketClient
     * @param request: the http request object
     * @param message: the closure reason message
     */
-    void sendCloseCtrlFrame(const string &reasonMsg = "");
+    void sendCloseCtrlFrame(const std::string &reasonMsg = "");
 
     /**
     * Send Ping Message Notification on the websocket
@@ -144,7 +144,7 @@ class WebSocketClient
     * @param request: the http request object
     * @param message: the content
     */
-    void sendPingCtrlFrame(const string &message);
+    void sendPingCtrlFrame(const std::string &message);
 
     /**
     * Send Pong Message Notification on the websocket
@@ -159,7 +159,7 @@ class WebSocketClient
     * @param request: the http request object
     * @param message: the content
     */
-    void sendPongCtrlFrame(const string &message);
+    void sendPongCtrlFrame(const std::string &message);
 
     HttpRequest *getHttpRequest() { return request; };
 

--- a/src/LocalRepository.cc
+++ b/src/LocalRepository.cc
@@ -88,6 +88,8 @@ bool LocalRepository::loadFilename_dir (const std::string& alias, const std::str
         loadFilename_dir(alias, path, subpath+"/"+entry->d_name);
     }
 
+    closedir (dir);
+
     return true;
 }
 

--- a/src/LocalRepository.cc
+++ b/src/LocalRepository.cc
@@ -22,11 +22,10 @@
 #include "libnavajo/LogRecorder.hh"
 #include "libnavajo/LocalRepository.hh"
 
-using namespace std;
 
 /**********************************************************************/
 
-LocalRepository::LocalRepository(const string& alias, const string& dirPath)
+LocalRepository::LocalRepository(const std::string& alias, const std::string& dirPath)
 {
   char resolved_path[4096];
 
@@ -55,12 +54,12 @@ void LocalRepository::reload()
 
 /**********************************************************************/
 
-bool LocalRepository::loadFilename_dir (const string& alias, const string& path, const string& subpath)
+bool LocalRepository::loadFilename_dir (const std::string& alias, const std::string& path, const std::string& subpath)
 {
     struct dirent *entry;
     DIR *dir;
     struct stat s;
-    string fullPath=path+subpath;
+    std::string fullPath=path+subpath;
 
     dir = opendir (fullPath.c_str());
     if (dir == NULL) return false;
@@ -72,14 +71,14 @@ bool LocalRepository::loadFilename_dir (const string& alias, const string& path,
 
       if (stat(filepath.c_str(), &s) == -1) 
       {
-        NVJ_LOG->append(NVJ_ERROR,string("LocalRepository - stat error : ")+string(strerror(errno)));
+        NVJ_LOG->append(NVJ_ERROR,std::string("LocalRepository - stat error : ")+std::string(strerror(errno)));
         continue;
       }
 
       int type=s.st_mode & S_IFMT;
       if (type == S_IFREG || type == S_IFLNK)
       {
-        string filename=alias+subpath+"/"+entry->d_name;
+        std::string filename=alias+subpath+"/"+entry->d_name;
         while (filename.size() && filename[0]=='/')
           filename.erase(0, 1);
         filenamesSet.insert(filename);
@@ -94,7 +93,7 @@ bool LocalRepository::loadFilename_dir (const string& alias, const string& path,
 
 /**********************************************************************/
 
-bool LocalRepository::fileExist(const string& url)
+bool LocalRepository::fileExist(const std::string& url)
 {
   return filenamesSet.find(url) != filenamesSet.end();
 }
@@ -111,7 +110,7 @@ void LocalRepository::printFilenames()
 
 bool LocalRepository::getFile(HttpRequest* request, HttpResponse *response)
 {
-  string url = request->getUrl();
+  std::string url = request->getUrl();
   size_t webpageLen;
   unsigned char *webpage;
   pthread_mutex_lock( &_mutex );
@@ -121,7 +120,7 @@ bool LocalRepository::getFile(HttpRequest* request, HttpResponse *response)
     
   pthread_mutex_unlock( &_mutex);
 
-  string resultat, filename=url;
+  std::string resultat, filename=url;
 
   if (aliasName.size())
     filename.replace(0, aliasName.size(), fullPathToLocalDir);

--- a/src/LocalRepository.cc
+++ b/src/LocalRepository.cc
@@ -22,6 +22,7 @@
 #include "libnavajo/LogRecorder.hh"
 #include "libnavajo/LocalRepository.hh"
 
+using namespace std;
 
 /**********************************************************************/
 

--- a/src/LogFile.cc
+++ b/src/LogFile.cc
@@ -25,7 +25,7 @@
   void LogFile::append(const NvjLogSeverity& l, const std::string& message, const std::string& details)
   {
     if (file!=NULL)
-      (*file) << message << endl;
+      (*file) << message << std::endl;
   }
 
   /***********************************************************************/
@@ -35,12 +35,12 @@
 
   void LogFile::initialize()
   {
-    file=new ofstream;
-    file->open(filename, ios::out | ios::app);
+    file=new std::ofstream;
+    file->open(filename, std::ios::out | std::ios::app);
 
     if (file->fail())
     {
-      	cerr <<"Can't open " << filename << endl;
+        std::cerr <<"Can't open " << filename << std::endl;
       	exit(1);
     }
   }

--- a/src/MPFDParser/Field.cc
+++ b/src/MPFDParser/Field.cc
@@ -10,17 +10,10 @@ pthread_mutex_t fileCreation_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 MPFD::Field::Field() {
     type = 0;
-    FieldContent = NULL;
-
-    FieldContentLength = 0;
 
 }
 
 MPFD::Field::~Field() {
-
-    if (FieldContent) {
-        delete FieldContent;
-    }
 
     if (type == FileType) {
         if (file.is_open()) {
@@ -51,20 +44,17 @@ int MPFD::Field::GetType() {
 
 void MPFD::Field::AcceptSomeData(char *data, long length) {
     if (type == TextType) {
-        if (FieldContent == NULL) {
-            FieldContent = new char[length + 1];
-        } else {
-            FieldContent = (char*) realloc(FieldContent, FieldContentLength + length + 1);
-        }
+        const size_t FieldContentLength = FieldContent.size();
+        const size_t newFieldContentLength = FieldContentLength + length + 1;
+        FieldContent.resize(newFieldContentLength);
 
-        memcpy(FieldContent + FieldContentLength, data, length);
-        FieldContentLength += length;
+        memcpy(&FieldContent[0] + FieldContentLength, data, length);
 
-        FieldContent[FieldContentLength] = 0;
+        FieldContent[newFieldContentLength-1] = 0;
     } else if (type == FileType) {
         if (WhereToStoreUploadedFiles == Parser::StoreUploadedFilesInFilesystem) {
             if (TempDir.length() > 0) {
-            
+	      
                 if (!file.is_open()) {
 pthread_mutex_lock( &fileCreation_mutex );
                     int i = 1;
@@ -99,13 +89,10 @@ pthread_mutex_unlock( &fileCreation_mutex );
                 throw MPFD::Exception("Trying to AcceptSomeData for a file but no TempDir is set.");
             }
         } else { // If files are stored in memory
-            if (FieldContent == NULL) {
-                FieldContent = new char[length];
-            } else {
-                FieldContent = (char*) realloc(FieldContent, FieldContentLength + length);
-            }
-            memcpy(FieldContent + FieldContentLength, data, length);
-            FieldContentLength += length;
+	    const size_t FieldContentLength = FieldContent.size();
+	    const size_t newFieldContentLength = FieldContentLength + length;
+            FieldContent.resize(newFieldContentLength);
+            memcpy(&FieldContent[0] + FieldContentLength, data, length);
         }
     } else {
         throw MPFD::Exception("Trying to AcceptSomeData but no type was set.");
@@ -122,7 +109,7 @@ unsigned long MPFD::Field::GetFileContentSize() {
     } else {
         if (type == FileType) {
             if (WhereToStoreUploadedFiles == Parser::StoreUploadedFilesInMemory) {
-                return FieldContentLength;
+	        return FieldContent.size();
             } else {
                 throw MPFD::Exception("Trying to get file content size, but uploaded files are stored in filesystem.");
             }
@@ -138,7 +125,7 @@ char * MPFD::Field::GetFileContent() {
     } else {
         if (type == FileType) {
             if (WhereToStoreUploadedFiles == Parser::StoreUploadedFilesInMemory) {
-                return FieldContent;
+                return &FieldContent[0];
             } else {
                 throw MPFD::Exception("Trying to get file content, but uploaded files are stored in filesystem.");
             }
@@ -155,10 +142,10 @@ std::string MPFD::Field::GetTextTypeContent() {
         if (type != TextType) {
             throw MPFD::Exception("Trying to get content of the field, but the type is not text.");
         } else {
-            if (FieldContent == NULL) {
+	    if (FieldContent.empty()) {
                 return std::string();
             } else {
-                return std::string(FieldContent);
+                return std::string(&FieldContent[0]);
             }
         }
     }

--- a/src/WebServer.cc
+++ b/src/WebServer.cc
@@ -43,15 +43,15 @@
 const char WebServer::authStr[]="Authorization: Basic ";
 const int WebServer::verify_depth=512;
 char *WebServer::certpass=NULL;
-string WebServer::webServerName;
+std::string WebServer::webServerName;
 pthread_mutex_t IpAddress::resolvIP_mutex = PTHREAD_MUTEX_INITIALIZER;
 HttpSession::HttpSessionsContainerMap HttpSession::sessions;
 pthread_mutex_t HttpSession::sessions_mutex=PTHREAD_MUTEX_INITIALIZER;
-const string WebServer::base64_chars = 
+const std::string WebServer::base64_chars =
              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
              "abcdefghijklmnopqrstuvwxyz"
              "0123456789+/";
-const string WebServer::webSocketMagicString="258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const std::string WebServer::webSocketMagicString="258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 
 time_t HttpSession::lastExpirationSearchTime=0;
@@ -145,7 +145,7 @@ void WebServer::updatePeerDnHistory(std::string dn)
 * @param name: set to the decoded login name  
 * @return true if user is allowed
 */ 
-bool WebServer::isUserAllowed(const string &pwdb64, string& login)
+bool WebServer::isUserAllowed(const std::string &pwdb64, std::string& login)
 {
 
   pthread_mutex_lock( &usersAuthHistory_mutex );
@@ -168,22 +168,22 @@ bool WebServer::isUserAllowed(const string &pwdb64, string& login)
 
   // It's a new user !
   bool authOK=false;
-  string loginPwd=base64_decode(pwdb64.c_str());
+  std::string loginPwd=base64_decode(pwdb64.c_str());
   size_t loginPwdSep=loginPwd.find(':');
-  if (loginPwdSep==string::npos)
+  if (loginPwdSep==std::string::npos)
   {
     pthread_mutex_unlock( &usersAuthHistory_mutex );
     return false;
   }
 
   login=loginPwd.substr(0,loginPwdSep);
-  string pwd=loginPwd.substr(loginPwdSep+1);
+  std::string pwd=loginPwd.substr(loginPwdSep+1);
 
-  vector<string> httpAuthLoginPwd=authLoginPwdList;
+  std::vector<std::string> httpAuthLoginPwd=authLoginPwdList;
   if (httpAuthLoginPwd.size())
   {
-    string logPass=login+':'+pwd;
-    for ( vector<string>::iterator it=httpAuthLoginPwd.begin(); it != httpAuthLoginPwd.end(); it++ )
+    std::string logPass=login+':'+pwd;
+    for ( std::vector<std::string>::iterator it=httpAuthLoginPwd.begin(); it != httpAuthLoginPwd.end(); it++ )
       if ( logPass == *it )
         authOK=true;
   }
@@ -248,7 +248,7 @@ bool WebServer::accept_request(ClientSockData* client)
   char *webSocketClientKey=NULL;
   bool websocket=false;
   int webSocketVersion=-1;
-  string username;
+  std::string username;
   int bufLineLen=0;
   BIO *ssl_bio = NULL;
 
@@ -333,7 +333,7 @@ bool WebServer::accept_request(ClientSockData* client)
         {
           j+=sizeof authStr - 1;
 
-          string pwdb64="";
+          std::string pwdb64="";
           while ( j < (unsigned)bufLineLen && *(bufLine + j) != 0x0d && *(bufLine + j) != 0x0a)
             pwdb64+=*(bufLine + j++);;
           if (!authOK)
@@ -609,7 +609,7 @@ bool WebServer::accept_request(ClientSockData* client)
     HttpRequest request(requestMethod, urlBuffer, requestParams, requestCookies, requestOrigin, username, client, mutipartContentParser);
 
     const char *mime=get_mime_type(urlBuffer); 
-    string mimeStr; if (mime != NULL) mimeStr=mime;
+    std::string mimeStr; if (mime != NULL) mimeStr=mime;
     HttpResponse response(mimeStr);
 
     std::vector<WebRepository *>::const_iterator repo=webRepositories.begin();
@@ -801,7 +801,7 @@ bool WebServer::httpSend(ClientSockData *client, const void *buf, size_t len)
 
 void WebServer::fatalError(const char *s)
 {
-  NVJ_LOG->append(NVJ_FATAL,string(s)+": "+string(strerror(errno)));
+  NVJ_LOG->append(NVJ_FATAL,std::string(s)+": "+std::string(strerror(errno)));
   ::exit(1);
 }
 
@@ -898,7 +898,7 @@ std::string WebServer::getHttpHeader(const char *messageType, const size_t len, 
   else
     header+="Connection: close\r\n";
 
-  string mimetype="text/html";
+  std::string mimetype="text/html";
   if (response != NULL)
     mimetype=response->getMimeType();
   header+="Content-Type: "+ mimetype  + "\r\n";
@@ -1250,8 +1250,8 @@ void WebServer::poolThreadProcessing()
 
       if (SSL_accept(ssl) <= 0)
       { const char *sslmsg=ERR_reason_error_string(ERR_get_error());
-        string msg="SSL accept error ";
-        if (sslmsg != NULL) msg+=": "+string(sslmsg);
+        std::string msg="SSL accept error ";
+        if (sslmsg != NULL) msg+=": "+std::string(sslmsg);
         NVJ_LOG->append(NVJ_DEBUG,msg);
       }
       
@@ -1554,9 +1554,9 @@ std::string WebServer::base64_encode(unsigned char const* bytes_to_encode, unsig
 * @param input - the string to encode
 * \return the encoded string
 ************************************************************************/
-string WebServer::SHA1_encode(const string& input)
+std::string WebServer::SHA1_encode(const std::string& input)
 {
-    string hash;
+    std::string hash;
     SHA_CTX context;
     SHA1_Init(&context);
     SHA1_Update(&context, &input[0], input.size());
@@ -1570,9 +1570,9 @@ string WebServer::SHA1_encode(const string& input)
 * @param webSocketKey - the websocket client key.
 * \return the websocket server key
 ************************************************************************/
-string WebServer::generateWebSocketServerKey(string webSocketKey)
+std::string WebServer::generateWebSocketServerKey(std::string webSocketKey)
 {
-  string sha1Key=SHA1_encode(webSocketKey+webSocketMagicString);
+  std::string sha1Key=SHA1_encode(webSocketKey+webSocketMagicString);
   return base64_encode(reinterpret_cast<const unsigned char*>(sha1Key.c_str()), sha1Key.length());
 }
 

--- a/src/WebSocketClient.cc
+++ b/src/WebSocketClient.cc
@@ -220,7 +220,7 @@ void WebSocketClient::receivingThread()
             }
             catch (std::exception& e)
             {
-              NVJ_LOG->append(NVJ_ERROR, string(" Websocket: nvj_gzip raised an exception: ") +  e.what());
+              NVJ_LOG->append(NVJ_ERROR, std::string(" Websocket: nvj_gzip raised an exception: ") +  e.what());
               msgLength = 0;
             }
           }
@@ -229,7 +229,7 @@ void WebSocketClient::receivingThread()
           {
             case 0x1:
               if (msgLength)
-                websocket->onTextMessage(this, string((char*)msgContent, msgLength), fin);
+                websocket->onTextMessage(this, std::string((char*)msgContent, msgLength), fin);
               else websocket->onTextMessage(this, "", fin);
               break;
             case 0x2:
@@ -395,7 +395,7 @@ void WebSocketClient::addSendingQueue(MessageContent *msgContent)
 
 /***********************************************************************/
 
-void WebSocketClient::sendTextMessage(const string &message, bool fin)
+void WebSocketClient::sendTextMessage(const std::string &message, bool fin)
 {
   MessageContent *msgContent = (MessageContent*)malloc( sizeof(MessageContent) );
   msgContent->opcode=0x1;
@@ -435,7 +435,7 @@ void WebSocketClient::sendPingCtrlFrame(const unsigned char* message, size_t len
   addSendingQueue(msgContent);
 }
 
-void WebSocketClient::sendPingCtrlFrame(const string &message)
+void WebSocketClient::sendPingCtrlFrame(const std::string &message)
 {
   sendPingCtrlFrame((const unsigned char*)message.c_str(), message.length());
 }
@@ -454,7 +454,7 @@ void WebSocketClient::sendPongCtrlFrame(const unsigned char* message, size_t len
   addSendingQueue(msgContent);
 }
 
-void WebSocketClient::sendPongCtrlFrame(const string &message)
+void WebSocketClient::sendPongCtrlFrame(const std::string &message)
 {
   sendPongCtrlFrame((const unsigned char*)message.c_str(), message.length());
 }
@@ -473,7 +473,7 @@ void WebSocketClient::sendCloseCtrlFrame(const unsigned char* message, size_t le
   addSendingQueue(msgContent);
 }
 
-void WebSocketClient::sendCloseCtrlFrame(const string &message)
+void WebSocketClient::sendCloseCtrlFrame(const std::string &message)
 {
   sendCloseCtrlFrame((const unsigned char*)message.c_str(), message.length());
 }

--- a/src/navajoPrecompiler.cc
+++ b/src/navajoPrecompiler.cc
@@ -103,6 +103,9 @@ bool loadFilename_dir (const std::string& path, const std::string& subpath="")
       if (type == S_IFDIR)
         loadFilename_dir(path, spath+entry->d_name);
     }
+
+    closedir (dir);
+
     return true;
 }
 
@@ -172,12 +175,13 @@ int main (int argc, char *argv[])
     // allocate memory to contain the whole file.
     buffer = (unsigned char*) malloc ((lSize+1)*sizeof(unsigned char));
     if (buffer == NULL)
-     { fprintf(stderr, "ERROR: can't malloc reading file: %s\n", filenamesVec[i].c_str()); exit (2); }
+      { fprintf(stderr, "ERROR: can't malloc reading file: %s\n", filenamesVec[i].c_str()); fclose(pFile); exit (2); }
 
     // copy the file into the buffer.
     if (fread (buffer,1,lSize,pFile) != lSize)
     {
       fprintf(stderr,"\nCan't read file %s ... ABORT !\n", filenamesVec[i].c_str() );
+      fclose(pFile);
       exit(1);
     };
 


### PR DESCRIPTION
Theses modifications do the following:
MPFDParse: 
- reduce use of new/delete in MPFDPaser.
  There were potential memory leaks in MPFDParser as new[] was used with delete and not delete[].
  I have modified MPFDParser to use std::vector instead. 
-  I have also corrected some warnings.
  [I have contacted the original author of MPFDParser, but apparently he does not maintain it anymore]
  libnavajo:
- Do not use "using namespace" in headers (because it can cause symbol collisions in users files)
- add missing closedir/fclose
- do not use 'const' on return type
- prefer out-of-source build (cf README.md)
