### PR TITLE
added some json support within requests

### DIFF
--- a/include/libnavajo/HttpRequest.hh
+++ b/include/libnavajo/HttpRequest.hh
@@ -53,6 +53,7 @@ class HttpRequest
   HttpRequestParametersMap parameters;
   std::string sessionId;
   MPFD::Parser *mutipartContentParser;
+  std::string jsonPayload ;
 
   /**********************************************************************/
   /**
@@ -364,7 +365,7 @@ class HttpRequest
     * @param params:  raw http parameters string
     * @cookies params: raw http cookies string
     */         
-    HttpRequest(const HttpRequestMethod type, const char *url, const char *params, const char *cookies, const char *origin, const std::string &username, ClientSockData *client, MPFD::Parser *parser=NULL)
+    HttpRequest(const HttpRequestMethod type, const char *url, const char *params, const char *cookies, const char *origin, const std::string &username, ClientSockData *client, const char *json, MPFD::Parser *parser=NULL)
     { 
       this->httpMethod = type;
       this->url = url;
@@ -372,6 +373,7 @@ class HttpRequest
       this->httpAuthUsername=username;
       this->clientSockData=client;
       this->mutipartContentParser=parser;
+      this->jsonPayload=json ;
       
       if (params != NULL && strlen(params))
         decodParams(params);
@@ -395,6 +397,13 @@ class HttpRequest
     */    
     inline MPFD::Parser *getMPFDparser() { return mutipartContentParser; };
     
+    /**********************************************************************/
+    /**
+    * get the MPFD parser
+    * @return a pointer to the MPFDparser instance
+    */
+    inline std::string getJsonPayload() { return jsonPayload; };
+
     /**********************************************************************/
     /**
     * get url    


### PR DESCRIPTION
Hi Thierry,

Here is what I could do within the afternoon. It just works.

I could test it with such a request : 
`$ curl -v -H "Content-Type: application/json" -X POST -d '{"creationDate":"2016-Sep-30 00:00:00","startDateMonthOffset":"1","endDateMonthOffset":"9"}' http://localhost:8080/keySet/generate`

Hope this helps.

Cheers,
