### PR TITLE
add HTTP PATCH and UPDATE methods in webserver

### DIFF
--- a/include/libnavajo/HttpRequest.hh
+++ b/include/libnavajo/HttpRequest.hh
@@ -27,7 +27,16 @@
 
 //****************************************************************************
 
-typedef enum { UNKNOWN_METHOD = 0, GET_METHOD = 1, POST_METHOD = 2, PUT_METHOD = 3, DELETE_METHOD = 4 } HttpRequestMethod;
+typedef enum {
+  UNKNOWN_METHOD = 0,
+  GET_METHOD = 1,
+  POST_METHOD = 2,
+  PUT_METHOD = 3,
+  DELETE_METHOD = 4,
+  UPDATE_METHOD = 5,
+  PATCH_METHOD = 6,
+} HttpRequestMethod;
+
 typedef enum { GZIP, ZLIB, NONE } CompressionMode;
 typedef struct
 {

--- a/src/WebServer.cc
+++ b/src/WebServer.cc
@@ -430,6 +430,12 @@ bool WebServer::accept_request(ClientSockData* client, bool authSSL)
             else
             if (strncmp(bufLine+j, "DELETE", 6) == 0)
               {  requestMethod=DELETE_METHOD; isQueryStr=true; j+=7; }
+              else
+              if (strncmp(bufLine+j, "UPDATE", 6) == 0)
+                {  requestMethod=UPDATE_METHOD; isQueryStr=true; j+=7; }
+                else
+                if (strncmp(bufLine+j, "PATCH", 5) == 0)
+                  {  requestMethod=PATCH_METHOD; isQueryStr=true; j+=6; }
 
         if (isQueryStr)
         {


### PR DESCRIPTION
Building REST api with libnavajo requires to support PATCH and UPDATE methods.

Signed-off-by: Julien Courtat <julien.courtat@aqsacom.com>