### PR TITLE
Compile failed on Mac

### DIFF
--- a/include/libnavajo/LogRecorder.hh
+++ b/include/libnavajo/LogRecorder.hh
@@ -20,6 +20,7 @@
 #include <list>
 #include <set>
 #include "libnavajo/LogOutput.hh"
+#include "libnavajo/nvjThread.h"
 
 #define NVJ_LOG LogRecorder::getInstance()
 #define NVJ_printf LogRecorder::getInstance()->printf


### PR DESCRIPTION
Class LogRecorder uses pthread_mutex_t but it does not include.