### PR TITLE
Free needs to be called on message inside MessageContent (fix memory leak)

### DIFF
--- a/include/libnavajo/WebSocketClient.hh
+++ b/include/libnavajo/WebSocketClient.hh
@@ -83,7 +83,9 @@ class WebSocketClient
     {
       while (!sendingQueue.empty())
       {
-        free(sendingQueue.front());
+        MessageContent *msg = sendingQueue.front();
+        free(msg->message);
+        free(msg);
         sendingQueue.pop();
       }
     }

--- a/src/WebSocketClient.cc
+++ b/src/WebSocketClient.cc
@@ -55,10 +55,12 @@ void WebSocketClient::sendingThread()
     long long msgLatency = (long long)( t.time - msg->date.time )*1000 + (long long)( t.millitm - msg->date.millitm );
     if ( msgLatency > snd_maxLatency || !sendMessage(msg))
     {
+      free(msg->message);
       free(msg);
       closeSend();
       return;
     }
+    free(msg->message);
     free(msg);
     pthread_mutex_lock(&sendingQueueMutex);
   }


### PR DESCRIPTION
While working on a program that sends tons of Jpeg data over a web socket I noticed there was a memory leak, at least with GCC7, by not calling free on the actual message data before freeing the MessageContent struct.

See issue: #25 