### PR TITLE
Retry to send a second time in httpSend if the socket is temporary blocked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ set(LIBNAVAJO_BUILD_DATE `/bin/date +%s`)
 ###############            Minimal flags           #####################
 IF(${UNIX})
   set (CMAKE_CXX_FLAGS " -Wall -O3 -g -DLINUX -Wextra -Wno-unused -fexceptions -fPIC -D_REENTRANT -DLIBNAVAJO_SOFTWARE_VERSION=\"\\\"${LIBNAVAJO_VERSION}\\\"\" -DDEBUG_TRACES")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.8 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
+    add_definitions(-std=c++11)
+  endif()
 ENDIF(${UNIX})
 
 IF(${APPLE})

--- a/src/WebServer.cc
+++ b/src/WebServer.cc
@@ -1006,13 +1006,14 @@ bool WebServer::httpSend(ClientSockData *client, const void *buf, size_t len)
   bool useSSL = client->bio != NULL;
   size_t totalSent=0;
   int sent=0;
+  unsigned char* buffer_left = (unsigned char*) buf;
 
   do
   {
     if ( useSSL )
-      sent = BIO_write(client->bio, buf, len);
+      sent = BIO_write(client->bio, buffer_left, len - totalSent);
     else
-      sent = sendCompat (client->socketId, buf, len, MSG_NOSIGNAL );
+      sent = sendCompat (client->socketId, buffer_left, len - totalSent, MSG_NOSIGNAL);
 
     if ( sent <= 0 )
     {
@@ -1030,8 +1031,11 @@ bool WebServer::httpSend(ClientSockData *client, const void *buf, size_t len)
         continue;
       }
     }
-    if (sent > 0) totalSent+=(size_t)sent;
-
+    else
+    {
+      totalSent+=(size_t)sent;
+      buffer_left += sent;
+    }
   }
   while (sent >= 0 && totalSent != len);
 

--- a/src/WebServer.cc
+++ b/src/WebServer.cc
@@ -1008,6 +1008,14 @@ bool WebServer::httpSend(ClientSockData *client, const void *buf, size_t len)
   int sent=0;
   unsigned char* buffer_left = (unsigned char*) buf;
 
+  fd_set writeset;
+  FD_ZERO(&writeset);
+  FD_SET(client->socketId, &writeset);
+  struct timeval tv;
+  tv.tv_sec = 10;
+  tv.tv_usec = 0;
+  int result;
+
   do
   {
     if ( useSSL )
@@ -1017,13 +1025,46 @@ bool WebServer::httpSend(ClientSockData *client, const void *buf, size_t len)
 
     if ( sent <= 0 )
     {
-      if ( ( sent < 0 ) 
-          || ( errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR )
-          || ( useSSL && !BIO_should_retry(client->bio) ) )
+      if ( sent < 0 )
       {
-        // write failed
-        //pthread_mutex_unlock (&client->client_mutex);
-        return false;
+        if ( errno == EAGAIN || errno == EWOULDBLOCK
+          || ( useSSL && BIO_should_retry(client->bio) ) )
+        {
+          NVJ_LOG->append(NVJ_ERROR, std::string("Webserver: send buffer full, retrying in 1 second"));
+          sleep (1);
+
+          /* retry to send data a second time before returning a failure to caller */
+          if ( useSSL )
+            sent = BIO_write(client->bio, buffer_left, len - totalSent);
+          else
+          {
+            result = select(client->socketId + 1, NULL, &writeset, NULL, &tv);
+
+            if ( (result <= 0) || (!FD_ISSET(client->socketId, &writeset)) )
+              return false;
+
+            sent = sendCompat (client->socketId, buffer_left, len - totalSent, MSG_NOSIGNAL);
+          }
+
+          if ( sent < 0 )
+          {
+            /* this is the second time it failed, no need to be more stubborn */
+            return false;
+          }
+          else
+          {
+            /* retry succeeded, don't forget to update counters and buffer left to send */
+            totalSent+=(size_t)sent;
+            buffer_left += sent;
+          }
+        }
+        else if (( errno == EINTR )
+              || ( useSSL && !BIO_should_retry(client->bio) ) )
+        {
+          // write failed
+          //pthread_mutex_unlock (&client->client_mutex);
+          return false;
+        }
       }
       else
       {


### PR DESCRIPTION
When the network connection has poor quality, the httpSend method might fail even if the failure is temporary.
Checking the return code of the underlying send function and retry if it's possible.