### PR TITLE
Fix SSL memory leaks in WebServer

### DIFF
--- a/include/libnavajo/WebServer.hh
+++ b/include/libnavajo/WebServer.hh
@@ -349,10 +349,11 @@ class WebServer
           delete client->peerDN;
           client->peerDN = NULL;
         }
+
+        if ( client->bio == NULL )
+          SSL_free (client->ssl);
+
         BIO_free_all(client->bio);
-/*        SSL_free (client->ssl);
-        if ( client->bio != NULL )
-          BIO_free (client->bio);*/
         client->ssl = NULL;
         client->bio = NULL;
       }


### PR DESCRIPTION
Three different memory leaks have been fixed:
 - sslCtx free on webserver exit
 - BIO free when SSL_new fails
 - the most important one, each time a SSL_accept fails, for exemple, if the client tries
   to connect without https, the leak happens for every connection attemps